### PR TITLE
Add branch information to hubEvals package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -31,7 +31,8 @@
     },
     {
         "package" : "hubEvals",
-        "url" : "https://github.com/hubverse-org/hubEvals"
+        "url" : "https://github.com/hubverse-org/hubEvals",
+        "branch" : "*release"
     },
     {
         "package" : "hubValidations",


### PR DESCRIPTION
I noticed that r-universe was still [building dev versions of hubEvals](https://hubverse-org.r-universe.dev/builds). This should fix it so it only builds released versions